### PR TITLE
Update requirements to Python >= 3.7 and Pystache >= 0.6

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -1,6 +1,19 @@
 Hacking on yaprogen
 ===================
 
+Deploy in development mode
+--------------------------
+
+When developing on Yaprogen, it is possible to test the program from a virtual
+environment::
+
+  python3 -m venv venv
+  source ./venv/bin/activate
+  pip3 install docutils
+  python setup.py develop
+
+The program will be available as ``venv/bin/yaprogen``.
+
 Translation
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -5,21 +5,36 @@ yaprogen - yet another project generator
 `yaprogen(1)` is a simple software project generator, which scaffolds some
 source code depending on a chosen template.
 
+Requirements
+============
+
+- Python 3.7 or above.
+
+Build
+=====
+
+Building is performed from the cloned repository in a `Python virtual
+environment`_::
+
+  python3 -m venv venv
+  source ./venv/bin/activate
+  pip3 install docutils
+  python setup.py bdist_wheel
+  deactivate
+
+This generates a Wheel file ``dist/yaprogen-X.Y.Z-py3-none-any.whl``, where
+"X.Y.Z" is the current version.
+
 Installation
 ============
 
-Requirements
-------------
+To install the generated Wheel file for all users, execute::
 
-- Python 3.x
+  sudo python3 -m pip install dist/yaprogen-X.Y.Z-py3-none-any.whl
 
-To install the program from cloned repository::
+To install the generated Wheel file for the current user, execute::
 
-  python3 setup.py install
-
-To install using `pip <https://pip.pypa.io/>`_::
-
-  pip3 install git+https://github.com/elebihan/yaprogen
+  python3 -m pip install --user dist/yaprogen-X.Y.Z-py3-none-any.whl
 
 Usage
 =====
@@ -31,3 +46,5 @@ License
 =======
 
 `GPL-3.0 <https://choosealicense.com/licenses/gpl-3.0/>`_
+
+.. _Python virtual environment: https://docs.python.org/3/library/venv.html

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,19 @@ setup(name='yaprogen',
       url='https://github.com/elebihan/yaprogen/',
       platforms=['Any'],
       keywords=['code generator', 'autotools'],
-      install_requires=['pystache >= 0.5'],
+      python_requires=">=3.7",
+      install_requires=[
+          'pystache >= 0.6'
+      ],
       classifiers=[
           'Development Status :: 3 - Alpha',
+          "Programming Language :: Python",
           'Programming Language :: Python :: 3',
+          "Programming Language :: Python :: 3.7",
+          "Programming Language :: Python :: 3.8",
+          "Programming Language :: Python :: 3.9",
+          "Programming Language :: Python :: 3.10",
+          "Programming Language :: Python :: Implementation :: CPython",
       ],
       packages=find_packages(),
       entry_points={


### PR DESCRIPTION
This pull request updates the requirements to Python >= 3.7 and Pystache >= 0.6, as well as the build instructions (to use a virtual environment).

Fixes #1 